### PR TITLE
adding debug to get release notes correctly

### DIFF
--- a/.github/actions/assemble-devnet/action.yml
+++ b/.github/actions/assemble-devnet/action.yml
@@ -101,3 +101,26 @@ runs:
         mv /tmp/besu ./
         mv config/ genesis/ profiles/ besu/
         tree .
+
+    - name: compile release notes
+      if: startsWith(github.ref, 'refs/tags/v')
+      id: release_create_artifacts
+      shell: bash      
+      run: |
+        mkdir release && cd release
+        tar -czvf linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz ../linea-besu/
+
+        echo "# Release Artifact: Linea - devnet" > output.md
+        echo "linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz" >> output.md
+        echo "SHA256: $(sha256sum linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz | awk '{ print $1 }' )" >> output.md
+        echo "" >> output.md
+
+        echo "### Besu and Plugin Details" >> output.md
+        echo "| Module | Version | SHA-256 |" >> output.md
+        echo "|--------|---------|--------------|" >> output.md
+        echo "| linea-besu | ${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }} | $(sha256sum /tmp/linea-besu-${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }}.tar.gz | awk '{ print $1 }' ) |" >> output.md
+        echo "| linea-sequencer-plugin | ${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/linea-sequencer-v${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
+        echo "| linea-tracer-plugin | ${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/linea-tracer-v${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
+        echo "| linea-finalized-tag-updater-plugin | ${{ steps.dotenv.outputs.FINALIZED_TAG_UPDATER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/finalized-tag-updater-v${{ steps.dotenv.outputs.FINALIZED_TAG_UPDATER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
+        echo "| shomei-plugin | ${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/besu-shomei-plugin-v${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
+        echo "" >> output.md

--- a/.github/actions/assemble-mainnet/action.yml
+++ b/.github/actions/assemble-mainnet/action.yml
@@ -102,3 +102,29 @@ runs:
         mv /tmp/besu ./
         mv config/ genesis/ profiles/ besu/
         tree .
+
+    - name: compile release notes
+      if: startsWith(github.ref, 'refs/tags/v')
+      id: release_create_artifacts
+      shell: bash      
+      run: |
+        mkdir release && cd release
+        tar -czvf linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz ../linea-besu/
+
+        echo "# Release Artifact: Linea - Mainnet" > output.md
+        echo "linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz" >> output.md
+        echo "SHA256: $(sha256sum linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz | awk '{ print $1 }' )" >> output.md
+        echo "" >> output.md
+
+        echo "### Besu and Plugin Details" >> output.md
+        echo "| Module | Version | SHA-256 |" >> output.md
+        echo "|--------|---------|--------------|" >> output.md
+        echo "| linea-besu | ${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }} | $(sha256sum /tmp/linea-besu-${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }}.tar.gz | awk '{ print $1 }' ) |" >> output.md
+        echo "| linea-sequencer-plugin | ${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/besu-sequencer-plugins-v${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
+        if [ -n "${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }}" ]; then
+        echo "| linea-tracer-plugin | ${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/linea-tracer-v${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
+        fi
+        echo "| linea-finalized-tag-updater-plugin | ${{ steps.dotenv.outputs.FINALIZED_TAG_UPDATER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/finalized-tag-updater-v${{ steps.dotenv.outputs.FINALIZED_TAG_UPDATER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
+        echo "| shomei-plugin | ${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/besu-shomei-plugin-v${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
+        echo "" >> output.md
+        

--- a/.github/actions/assemble-sepolia/action.yml
+++ b/.github/actions/assemble-sepolia/action.yml
@@ -100,3 +100,26 @@ runs:
         mv /tmp/besu ./
         mv config/ genesis/ profiles/ besu/
         tree .
+
+    - name: compile release notes
+      if: startsWith(github.ref, 'refs/tags/v')
+      id: release_create_artifacts
+      shell: bash      
+      run: |
+        mkdir release && cd release
+        tar -czvf linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz ../linea-besu/
+
+        echo "# Release Artifact: Linea - Sepolia" > output.md
+        echo "linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz" >> output.md
+        echo "SHA256: $(sha256sum linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz | awk '{ print $1 }' )" >> output.md
+        echo "" >> output.md
+
+        echo "### Besu and Plugin Details" >> output.md
+        echo "| Module | Version | SHA-256 |" >> output.md
+        echo "|--------|---------|--------------|" >> output.md
+        echo "| linea-besu | ${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }} | $(sha256sum /tmp/linea-besu-${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }}.tar.gz | awk '{ print $1 }' ) |" >> output.md
+        echo "| linea-sequencer-plugin | ${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/linea-sequencer-v${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
+        echo "| linea-tracer-plugin | ${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/linea-tracer-v${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
+        echo "| linea-finalized-tag-updater-plugin | ${{ steps.dotenv.outputs.FINALIZED_TAG_UPDATER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/finalized-tag-updater-v${{ steps.dotenv.outputs.FINALIZED_TAG_UPDATER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
+        echo "| shomei-plugin | ${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/besu-shomei-plugin-v${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
+        echo "" >> output.md

--- a/.github/workflows/linea-devnet.yml
+++ b/.github/workflows/linea-devnet.yml
@@ -84,7 +84,19 @@ jobs:
           tags: |
             consensys/linea-besu-package:devnet-latest
 
+      ### get the version numbers to create the release notes
+      - name: get versions via dotenv
+        id: dotenv
+        uses: falti/dotenv-action@v1
+        with:
+          path: versions/linea-devnet.env
+          mode: development
+          keys-case: lower
+          log-variables: true
+          load-mode: strict
+
       ### release package artifacts
+      ### create the release and attach the release notes
       - name: release on tag - create artifacts for a release
         if: startsWith(github.ref, 'refs/tags/v')
         id: release_create_artifacts

--- a/.github/workflows/linea-devnet.yml
+++ b/.github/workflows/linea-devnet.yml
@@ -84,44 +84,16 @@ jobs:
           tags: |
             consensys/linea-besu-package:devnet-latest
 
-      ### get the version numbers to create the release notes
-      - name: get versions via dotenv
-        id: dotenv
-        uses: falti/dotenv-action@v1
-        with:
-          path: versions/linea-devnet.env
-          mode: development
-          keys-case: lower
-          log-variables: true
-          load-mode: strict
-
-      ### release package artifacts
-      ### create the release and attach the release notes
-      - name: release on tag - create artifacts for a release
+      ### update the release notes with docker hashes
+      - name: create the release notes and then the release
         if: startsWith(github.ref, 'refs/tags/v')
         id: release_create_artifacts
         run: |
-          mkdir release && cd release
-          tar -czvf linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz ../linea-besu/
-
-          echo "## Release Artifact: Linea - devnet" > output.md
-          echo "linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz" >> output.md
-          echo "SHA256: $(sha256sum linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz | awk '{ print $1 }' )" >> output.md
-          echo "" >> output.md
-
-          echo "## Besu and Plugin Details" >> output.md
-          echo "| Module | Version | SHA-256 |" >> output.md
-          echo "|--------|---------|--------------|" >> output.md
-          echo "| linea-besu | ${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }} | $(sha256sum /tmp/linea-besu-${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }}.tar.gz | awk '{ print $1 }' ) |" >> output.md
-          echo "| linea-sequencer-plugin | ${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/besu-sequencer-plugins-v${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "| linea-tracer-plugin | ${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/linea-tracer-v${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "| linea-finalized-tag-updater-plugin | ${{ steps.dotenv.outputs.FINALIZED_TAG_UPDATER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/finalized-tag-updater-v${{ steps.dotenv.outputs.FINALIZED_TAG_UPDATER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "| shomei-plugin | ${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/besu-shomei-plugin-v${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "" >> output.md
-
+          cd release
+          
           MANIFEST=$(docker manifest inspect consensys/linea-besu-package:${{ steps.assemble.outputs.dockertag }})
           if [ $? -eq 0 ]; then
-            echo "## Docker Image Details" >> output.md
+            echo "### Docker Image Details" >> output.md
             echo "" >> output.md
             echo "To pull the image, use the following command:" >> output.md
             echo "\`\`\`" >> output.md

--- a/.github/workflows/linea-mainnet.yml
+++ b/.github/workflows/linea-mainnet.yml
@@ -95,35 +95,16 @@ jobs:
           log-variables: true
           load-mode: strict
 
-      ### release package artifacts
-      ### create the release and attach the release notes
-      - name: release on tag - create artifacts for a release
+      ### update the release notes with docker hashes
+      - name: create the release notes and then the release
         if: startsWith(github.ref, 'refs/tags/v')
         id: release_create_artifacts
         run: |
-          mkdir release && cd release
-          tar -czvf linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz ../linea-besu/
-
-          echo "## Release Artifact: Linea - Mainnet" > output.md
-          echo "linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz" >> output.md
-          echo "SHA256: $(sha256sum linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz | awk '{ print $1 }' )" >> output.md
-          echo "" >> output.md
-
-          echo "## Besu and Plugin Details" >> output.md
-          echo "| Module | Version | SHA-256 |" >> output.md
-          echo "|--------|---------|--------------|" >> output.md
-          echo "| linea-besu | ${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }} | $(sha256sum /tmp/linea-besu-${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }}.tar.gz | awk '{ print $1 }' ) |" >> output.md
-          echo "| linea-sequencer-plugin | ${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/besu-sequencer-plugins-v${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          if [ -n "${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }}" ]; then
-          echo "| linea-tracer-plugin | ${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/linea-tracer-v${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          fi
-          echo "| linea-finalized-tag-updater-plugin | ${{ steps.dotenv.outputs.FINALIZED_TAG_UPDATER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/finalized-tag-updater-v${{ steps.dotenv.outputs.FINALIZED_TAG_UPDATER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "| shomei-plugin | ${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/besu-shomei-plugin-v${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "" >> output.md
+          cd release
 
           MANIFEST=$(docker manifest inspect consensys/linea-besu-package:${{ steps.assemble.outputs.dockertag }})
           if [ $? -eq 0 ]; then
-            echo "## Docker Image Details" >> output.md
+            echo "### Docker Image Details" >> output.md
             echo "" >> output.md
             echo "To pull the image, use the following command:" >> output.md
             echo "\`\`\`" >> output.md
@@ -137,7 +118,6 @@ jobs:
             echo "Docker image consensys/linea-besu-package:${{ steps.assemble.outputs.dockertag }} does not exist on dockerhub"
             exit 1
           fi
-          cat output.md
 
       - name: upload linea-mainnet artifacts
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/linea-mainnet.yml
+++ b/.github/workflows/linea-mainnet.yml
@@ -84,7 +84,19 @@ jobs:
           tags: |
             consensys/linea-besu-package:mainnet-latest
 
+      ### get the version numbers to create the release notes
+      - name: get versions via dotenv
+        id: dotenv
+        uses: falti/dotenv-action@v1
+        with:
+          path: versions/linea-mainnet.env
+          mode: development
+          keys-case: lower
+          log-variables: true
+          load-mode: strict
+
       ### release package artifacts
+      ### create the release and attach the release notes
       - name: release on tag - create artifacts for a release
         if: startsWith(github.ref, 'refs/tags/v')
         id: release_create_artifacts
@@ -125,6 +137,7 @@ jobs:
             echo "Docker image consensys/linea-besu-package:${{ steps.assemble.outputs.dockertag }} does not exist on dockerhub"
             exit 1
           fi
+          cat output.md
 
       - name: upload linea-mainnet artifacts
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/linea-sepolia.yml
+++ b/.github/workflows/linea-sepolia.yml
@@ -83,7 +83,19 @@ jobs:
           tags: |
             consensys/linea-besu-package:sepolia-latest  
 
+      ### get the version numbers to create the release notes
+      - name: get versions via dotenv
+        id: dotenv
+        uses: falti/dotenv-action@v1
+        with:
+          path: versions/linea-sepolia.env
+          mode: development
+          keys-case: lower
+          log-variables: true
+          load-mode: strict
+
       ### release package artifacts
+      ### create the release and attach the release notes
       - name: release on tag - create artifacts for a release
         if: startsWith(github.ref, 'refs/tags/v')
         id: release_create_artifacts

--- a/.github/workflows/linea-sepolia.yml
+++ b/.github/workflows/linea-sepolia.yml
@@ -83,44 +83,16 @@ jobs:
           tags: |
             consensys/linea-besu-package:sepolia-latest  
 
-      ### get the version numbers to create the release notes
-      - name: get versions via dotenv
-        id: dotenv
-        uses: falti/dotenv-action@v1
-        with:
-          path: versions/linea-sepolia.env
-          mode: development
-          keys-case: lower
-          log-variables: true
-          load-mode: strict
-
-      ### release package artifacts
-      ### create the release and attach the release notes
-      - name: release on tag - create artifacts for a release
+      ### update the release notes with docker hashes
+      - name: create the release notes and then the release
         if: startsWith(github.ref, 'refs/tags/v')
         id: release_create_artifacts
         run: |
-          mkdir release && cd release
-          tar -czvf linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz ../linea-besu/
-
-          echo "## Release Artifact: Linea - Sepolia" > output.md
-          echo "linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz" >> output.md
-          echo "SHA256: $(sha256sum linea-besu-${{ steps.assemble.outputs.dockertag }}.tar.gz | awk '{ print $1 }' )" >> output.md
-          echo "" >> output.md
-
-          echo "## Besu and Plugin Details" >> output.md
-          echo "| Module | Version | SHA-256 |" >> output.md
-          echo "|--------|---------|--------------|" >> output.md
-          echo "| linea-besu | ${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }} | $(sha256sum /tmp/linea-besu-${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }}.tar.gz | awk '{ print $1 }' ) |" >> output.md
-          echo "| linea-sequencer-plugin | ${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/linea-sequencer-v${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "| linea-tracer-plugin | ${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/linea-tracer-v${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "| linea-finalized-tag-updater-plugin | ${{ steps.dotenv.outputs.FINALIZED_TAG_UPDATER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/finalized-tag-updater-v${{ steps.dotenv.outputs.FINALIZED_TAG_UPDATER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "| shomei-plugin | ${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }} | $(sha256sum ../linea-besu/besu/plugins/besu-shomei-plugin-v${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "" >> output.md
-
+          cd release
+          
           MANIFEST=$(docker manifest inspect consensys/linea-besu-package:${{ steps.assemble.outputs.dockertag }})
           if [ $? -eq 0 ]; then
-            echo "## Docker Image Details" >> output.md
+            echo "### Docker Image Details" >> output.md
             echo "" >> output.md
             echo "To pull the image, use the following command:" >> output.md
             echo "\`\`\`" >> output.md


### PR DESCRIPTION
Fixes #156. Have moved the release notes creation to within the composite action so the versions + artifact paths are in one place to edit only. The outer workflows create the docker images and update the release notes and publish