### PR TITLE
remove tx-pool-disable-locals

### DIFF
--- a/linea-besu/profiles/advanced-mainnet.toml
+++ b/linea-besu/profiles/advanced-mainnet.toml
@@ -20,7 +20,6 @@ Xsnapsync-synchronizer-flat-db-healing-enabled=true
 
 ### Transaction pool ###
 tx-pool-enable-save-restore=true
-tx-pool-disable-locals=true
 tx-pool-price-bump=1
 tx-pool-max-future-by-sender=1000
 tx-pool-min-gas-price="20000000"

--- a/linea-besu/profiles/advanced-sepolia.toml
+++ b/linea-besu/profiles/advanced-sepolia.toml
@@ -21,7 +21,6 @@ Xsnapsync-synchronizer-flat-db-healing-enabled=true
 
 ### Transaction pool ###
 tx-pool-enable-save-restore=true
-tx-pool-disable-locals=true
 tx-pool-price-bump=1
 tx-pool-max-future-by-sender=1000
 tx-pool-min-gas-price="10000000"


### PR DESCRIPTION
The Besu option tx-pool-disable-locals has been deprecated since [23.10.1](https://github.com/hyperledger/besu/blob/main/CHANGELOG.md#23101) (use equivalent tx-pool-no-local-priority instead). Should be an easy find and replace to change it over. 

These 2 config files had both specified, so removed the deprecated version.