### PR TITLE
update sepolia limits file to match v2

### DIFF
--- a/linea-besu/config/trace-limits.sepolia.toml
+++ b/linea-besu/config/trace-limits.sepolia.toml
@@ -2,75 +2,60 @@
 #
 # Arithmetization module limits
 #
-ADD                 = 524286
-BIN                 = 262128
-BIN_RT              = 262144
-EC_DATA             = 4084
-EXT                 = 1048500
-HUB                 = 2097150
+ADD                 = 524288
+BIN                 = 262144
+BLAKE_MODEXP_DATA	= 16384
+BLOCK_DATA          = 1024
+BLOCK_HASH          = 512
+EC_DATA             = 262144
+EUC                 = 65536
+EXP                 = 8192
+EXT	                = 1048576
+GAS	                = 65536
+HUB                 = 2097152
+LOG_DATA            = 65536
+LOG_INFO            = 4096
+MMIO                = 4194304
+MMU                 = 4194304
+MOD                 = 131072
+MUL                 = 65536
+MXP                 = 524288
+OOB                 = 262144
+RLP_ADDR            = 4096
+RLP_TXN             = 131072
+RLP_TXN_RCPT        = 65536
+ROM                 = 4194304
+ROM_LEX             = 1024
+SHAKIRA_DATA        = 32768
+SHF                 = 65536
+STP                 = 16384
+TRM                 = 32768
+TXN_DATA            = 8192
+WCP                 = 262144
+#
+# Reference table limits
+#
+BIN_REFERENCE_TABLE = 262144
+SHF_REFERENCE_TABLE = 4096
 INSTRUCTION_DECODER = 512
-MMIO                = 1048576
-MMU                 = 524288
-MMU_ID              = 256
-MOD                 = 131064
-MUL                 = 65527
-MXP                 = 524284
-PHONEY_RLP          = 65536
-PUB_HASH            = 30768
-PUB_HASH_INFO       = 8192
-OLD_PUB_HASH        = 32768
-OLD_PUB_HASH_INFO   = 8192
-PUB_LOG             = 14384
-PUB_LOG_INFO        = 49152
-RLP                 = 504
-ROM                 = 13000000
-ROM_LEX             = 3145728
-SHF                 = 65520
-SHF_RT              = 4096
-TX_RLP              = 110000
-WCP                 = 262128
-LOG_DATA            = 16384
-LOG_INFO            = 16384
-RLP_ADDR            = 504
-
-#
-# These do not exist yet
-#
-RLP_TXRCPT          = 2621440
-TXN_DATA            = 2621440
-STP                 = 2621440
-TRM                 = 1000000
-EUC                 = 1000000
-
-#
-# Block-specific limits
-#
-BLOCK_TX       = 200
-BLOCK_L1SIZE   = 108592
-BLOCK_L2L1LOGS = 16
-BLOCK_KECCAK   = 8192
-
 #
 # Precompiles limits
 #
-PRECOMPILE_ECRECOVER = 100
-PRECOMPILE_ECRECOVER_EFFECTIVE_CALL = 1000000
-PRECOMPILE_SHA2      = 100
-PRECOMPILE_SHA2_BLOCKS = 1000000
-PRECOMPILE_SHA2_EFFECTIVE_CALL = 1000000
-PRECOMPILE_RIPEMD    = 100
-PRECOMPILE_RIPEMD_EFFECTIVE_CALL = 1000000
-PRECOMPILE_RIPEMD_BLOCKS = 1000000
-PRECOMPILE_IDENTITY  = 10000
-PRECOMPILE_MODEXP    = 1000
-PRECOMPILE_MODEXP_EFFECTIVE_CALL = 1000
-PRECOMPILE_ECADD     = 1000
-PRECOMPILE_ECADD_EFFECTIVE_CALL     = 1000000
-PRECOMPILE_ECMUL     = 100
-PRECOMPILE_ECMUL_EFFECTIVE_CALL     = 1000000
-PRECOMPILE_ECPAIRING = 100
-PRECOMPILE_ECPAIRING_EFFECTIVE_CALL = 1000000
-PRECOMPILE_ECPAIRING_MILLER_LOOP = 1000000
-PRECOMPILE_BLAKE2F   = 512
-PRECOMPILE_BLAKE2F_ROUNDS = 1000000
-PRECOMPILE_ECPAIRING_WEIGHTED = 1000000
+PRECOMPILE_ECRECOVER_EFFECTIVE_CALLS     = 128
+PRECOMPILE_SHA2_BLOCKS                   = 671
+PRECOMPILE_RIPEMD_BLOCKS                 = 671
+PRECOMPILE_MODEXP_EFFECTIVE_CALLS        = 4
+PRECOMPILE_ECADD_EFFECTIVE_CALLS         = 16384
+PRECOMPILE_ECMUL_EFFECTIVE_CALLS         = 32
+PRECOMPILE_ECPAIRING_FINAL_EXPONENTIATIONS = 16
+PRECOMPILE_ECPAIRING_G2_MEMBERSHIP_CALLS    = 64
+PRECOMPILE_ECPAIRING_MILLER_LOOPS        = 64
+PRECOMPILE_BLAKE_EFFECTIVE_CALLS         = 600
+PRECOMPILE_BLAKE_ROUNDS                  = 600
+#
+# Block-specific limits
+#
+BLOCK_KECCAK       = 8192
+BLOCK_L1_SIZE      = 1000000
+BLOCK_L2_L1_LOGS   = 16
+BLOCK_TRANSACTIONS = 200


### PR DESCRIPTION
Ref https://consensys.slack.com/archives/C03957X9XKP/p1741225511878819?thread_ts=1736418042.130569&cid=C03957X9XKP

Sepolia is supposed to use the [v2](https://github.com/Consensys/zkevm-monorepo/blob/f254667b0e23c0e2a7254f2a8990201b5aa42438/config/common/traces-limits-besu-v2.toml) names for its limits, whereas mainnet should still use [v1](https://github.com/Consensys/zkevm-monorepo/blob/f254667b0e23c0e2a7254f2a8990201b5aa42438/config/common/traces-limits-besu-v1.toml). In linea-besu-package [both](https://github.com/Consensys/linea-besu-package/blob/main/linea-besu/config/trace-limits.sepolia.toml) [network](https://github.com/Consensys/linea-besu-package/blob/main/linea-besu/config/trace-limits.mainnet.toml)s configs still use the v1 style, so sepolia is missing new configs and a rename and so complains that it is missing SHAKIRA_DATA