### PR TITLE
replace deprecated option

### DIFF
--- a/linea-besu/profiles/advanced-mainnet.toml
+++ b/linea-besu/profiles/advanced-mainnet.toml
@@ -16,7 +16,7 @@ max-peers=50
 node-private-key-file="/data/key"
 genesis-file="genesis/genesis.mainnet.json" # Path to the custom genesis file
 sync-mode="SNAP"
-Xsnapsync-synchronizer-flat-db-healing-enabled=true
+Xbonsai-full-flat-db-enabled=true
 
 ### Transaction pool ###
 tx-pool-enable-save-restore=true

--- a/linea-besu/profiles/advanced-sepolia.toml
+++ b/linea-besu/profiles/advanced-sepolia.toml
@@ -17,7 +17,7 @@ max-peers=50
 node-private-key-file="/data/key"
 genesis-file="genesis/genesis.testnet-sepolia.json" # Path to the custom genesis file
 sync-mode="SNAP"
-Xsnapsync-synchronizer-flat-db-healing-enabled=true
+Xbonsai-full-flat-db-enabled=true
 
 ### Transaction pool ###
 tx-pool-enable-save-restore=true

--- a/linea-besu/profiles/basic-mainnet.toml
+++ b/linea-besu/profiles/basic-mainnet.toml
@@ -7,7 +7,7 @@ genesis-file="genesis/genesis.mainnet.json" # Path to the custom genesis file
 # Sync mode and data layer implementation
 sync-mode="SNAP"
 data-storage-format="BONSAI"
-Xsnapsync-synchronizer-flat-db-healing-enabled=true
+Xbonsai-full-flat-db-enabled=true
 
 # data
 data-path="/data"

--- a/linea-besu/profiles/basic-sepolia.toml
+++ b/linea-besu/profiles/basic-sepolia.toml
@@ -11,7 +11,7 @@ node-private-key-file="/data/key"
 # Sync mode and data layer implementation
 sync-mode="SNAP"
 data-storage-format="BONSAI"
-Xsnapsync-synchronizer-flat-db-healing-enabled=true
+Xbonsai-full-flat-db-enabled=true
 
 # Boot nodes and static nodes
 bootnodes=["enode://6f20afbe4397e51b717a7c1ad3095e79aee48c835eebd9237a3e8a16951ade1fe0e66e981e30ea269849fcb6ba03d838da37f524fabd2a557474194a2e2604fa@18.221.100.27:31002,enode://ce1e0d8e0500cb5c0ac56bdcdafb2d6320c3a2c5125b5ccf12f5dfc9b47ee74acbcafc32559017613136c9c36a0ce74ba4f83b7fb8244f099f3b15708d9d3129@3.23.75.47:31000,enode://1b026a5eb0ae74300f58987d235ef0e3a550df963345cb3574be3b0b54378bd11f14dfd515a8976f2c2d2826090e9507b8ccc24f896a9ffffffcabcfd996a733@3.129.120.128:31001"]


### PR DESCRIPTION
Upcoming breaking change in besu
- `--Xsnapsync-synchronizer-flat-db-healing-enabled` is deprecated, use `--Xbonsai-full-flat-db-enabled` instead.
